### PR TITLE
Make some Yaspi arguments pathlib.Path

### DIFF
--- a/yaspi/yaspi.py
+++ b/yaspi/yaspi.py
@@ -22,8 +22,8 @@ class Yaspi:
             cmd: str,
             prep: str,
             recipe: str,
-            gen_script_dir: str,
-            log_dir: str,
+            gen_script_dir: Path,
+            log_dir: Path,
             partition: str,
             job_array_size: int,
             cpus_per_task: int,
@@ -57,7 +57,7 @@ class Yaspi:
         self.gpus_per_task = gpus_per_task
         self.constraint_str = constraint_str
         self.throttle_array = throttle_array
-        self.gen_script_dir = Path(gen_script_dir)
+        self.gen_script_dir = gen_script_dir
         self.job_array_size = job_array_size
         self.use_custom_ray_tmp_dir = use_custom_ray_tmp_dir
         self.slurm_logs = None
@@ -305,12 +305,14 @@ def main():
     parser.add_argument("--recipe", default="ray",
                         help="the SLURM recipe to use to generate scripts")
     parser.add_argument("--template_dir",
+                        type=Path,
                         help="if given, override directory containing SLURM templates")
     parser.add_argument("--partition", default="gpu",
                         help="The name of the SLURM partition used to run the job")
     parser.add_argument("--time_limit", default="96:00:00",
                         help="The maximum amount of time allowed to run the job")
     parser.add_argument("--gen_script_dir", default="data/slurm-gen-scripts",
+                        type=Path,
                         help="directory in which generated slurm scripts will be stored")
     parser.add_argument("--cmd", default='echo "hello"',
                         help="single command (or comma separated commands) to run")

--- a/yaspi_test/test_yaspi.py
+++ b/yaspi_test/test_yaspi.py
@@ -6,12 +6,19 @@ github workflow, but github doesn't give me enough free testing minutes for that
 """
 
 import json
+from pathlib import Path
 from yaspi.yaspi import Yaspi
+
+
+PATH_ARGS = {"gen_script_dir", "log_dir", "template_dir"}
 
 
 def test_yaspi_object_creation():
     with open("yaspi_test/misc/dummy_yaspi_config.json", "r") as f:
         yaspi_defaults = json.load(f)
+    for key, val in yaspi_defaults.items():
+        if key in PATH_ARGS:
+            yaspi_defaults[key] = Path(val)
     cmd = "python yaspi_test/misc/hello_world.py"
     job_name = "test_yaspi"
     job_queue = ""


### PR DESCRIPTION
The current master fails for me with:

```
Traceback (most recent call last):
  File "/home/area0318/.local/bin/yaspi", line 8, in <module>
    sys.exit(main())
  File "/home/area0318/.local/lib/python3.7/site-packages/yaspi/yaspi.py", line 377, in main
    **prop_kwargs,
  File "<string>", line 114, in __beartyped___init__
  File "/home/area0318/.local/lib/python3.7/site-packages/beartype/_decor/_code/_pep/_error/peperror.py", line 221, in raise_pep_call_exception
    f'{pith_label} violates type hint '
beartype.roar.BeartypeCallHintPepParamException: @beartyped __init__() parameter log_dir="PosixPath('data/slurm-logs')" violates type hint <class 'str'>, as value "PosixPath('data/slurm-logs')" not str.
```

I fixed this and also went ahead and standardised all the path arguments to use pathlib.Path.