### PR TITLE
Factor out _add_batch_resources in Yaspi class

### DIFF
--- a/yaspi/yaspi.py
+++ b/yaspi/yaspi.py
@@ -125,11 +125,7 @@ class Yaspi:
                     "env_setup": self.env_setup,
                 },
             }
-            if self.gpus_per_task:
-                resource_str = f"#SBATCH --gres=gpu:{self.gpus_per_task}"
-            if self.constraint_str:
-                resource_str = f"{resource_str}\n{self.constraint_str}"
-                rules["sbatch"]["sbatch_resources"] = resource_str
+            self._add_batch_resources(rules)
         elif self.recipe in {"cpu-proc", "gpu-proc"}:
             if self.env_setup is None:
                 # TODO(Samuel): configure this more sensibly
@@ -165,15 +161,9 @@ class Yaspi:
                     "time_limit": self.time_limit,
                     "cpus_per_task": self.cpus_per_task,
                     "exclude_nodes": f"#SBATCH --exclude={self.exclude}",
-                    "sbatch_resources": "",
                 },
             }
-            resource_strs = []
-            if self.constraint_str:
-                resource_strs.append(f"#SBATCH --constraint={self.constraint_str}")
-            if self.gpus_per_task and self.recipe == "gpu-proc":
-                resource_strs.append(f"#SBATCH --gres=gpu:{self.gpus_per_task}")
-            rules["sbatch"]["sbatch_resources"] = "\n".join(resource_strs)
+            self._add_batch_resources(rules, self.recipe == "gpu-proc")
         else:
             raise ValueError(f"template: {self.recipe} unrecognised")
 
@@ -190,6 +180,14 @@ class Yaspi:
                 print(f"Writing slurm script ({key}) to {dest_path}")
                 f.write(gen)
             dest_path.chmod(0o755)
+
+    def _add_batch_resources(self, rules, allow_gpu=True):
+        resource_strs = []
+        if self.constraint_str:
+            resource_strs.append(f"#SBATCH --constraint={self.constraint_str}")
+        if self.gpus_per_task and allow_gpu:
+            resource_strs.append(f"#SBATCH --gres=gpu:{self.gpus_per_task}")
+        rules["sbatch"]["sbatch_resources"] = "\n".join(resource_strs)
 
     def get_log_paths(self):
         watched_logs = []


### PR DESCRIPTION
The current approach doesn't work with the ray recipe if no constraints are passed, but this could still be useful e.g. on clusters that give a reasonable allocation by default e.g. always allocate in exclusive mode.

```
Writing slurm script (master) to data/slurm-gen-scripts/ray/ray-master.sh
Traceback (most recent call last):
  File "yaspi/yaspi.py", line 385, in <module>
    main()
  File "yaspi/yaspi.py", line 358, in main
    job = Yaspi(
  File "<string>", line 393, in __beartyped___init__
  File "yaspi/yaspi.py", line 66, in __init__
    self.generate_scripts()
  File "yaspi/yaspi.py", line 185, in generate_scripts
    gen = self.fill_template(template_path=template_path, rules=rules[key])
  File "<string>", line 47, in __beartyped_fill_template
  File "yaspi/yaspi.py", line 283, in fill_template
    token = rules[key]
KeyError: 'sbatch_resources'
```